### PR TITLE
Add gpsToMeters to world_interface.h

### DIFF
--- a/noop_world.cpp
+++ b/noop_world.cpp
@@ -20,6 +20,11 @@ transform_t readGPS() {
   return toTransform({0,0,0});
 }
 
+point_t gpsToMeters(double lon, double lat)
+{
+  return {lon, lat, 1.0};
+}
+
 transform_t readOdom() {
   return toTransform({0,0,0});
 }

--- a/simulator_world.cpp
+++ b/simulator_world.cpp
@@ -29,6 +29,11 @@ transform_t readGPS() {
   return world.readGPS();
 }
 
+point_t gpsToMeters(double lon, double lat)
+{
+  return {lon, lat, 1.0};
+}
+
 transform_t readOdom() {
   return world.readOdom();
 }

--- a/world_interface.h
+++ b/world_interface.h
@@ -8,6 +8,7 @@ points_t readLidarScan();
 points_t readLandmarks();
 transform_t readGPS();
 transform_t readOdom();
+point_t gpsToMeters(double lon, double lat);
 
 // `index` must be in the range 0-6 (the URC competition will have 7 legs)
 URCLeg getLeg(int index);


### PR DESCRIPTION
For the simulator our "GPS" readings have always been given in terms of meters, but it's different on the real rover. We should abstract away this functionality.