### PR TITLE
Change 2D_slam example to handle no heading GPS information

### DIFF
--- a/2D_slam.cpp
+++ b/2D_slam.cpp
@@ -7,44 +7,7 @@
 #include "constants.h"
 using namespace NavSim;
 
-Graph smooth(const values &x0, const traj_points_t &readings) {
-  int T = (int) readings.size()-1;
-  int nLandmarks = (int) readings[0].size();
-  assert("whoohoo" && (x0.size() == T*3 + nLandmarks*2));
-  covariance<3> odom_cov = covariance<3>::Zero();
-  // TODO what are the right numbers here? Should y be correlated with theta?
-  odom_cov << SLAM_VAR, 0, 0,
-              0, SLAM_VAR, SLAM_VAR/2.0,
-              0, SLAM_VAR/2.0, SLAM_VAR;
-  covariance<3> odom_cov_inv = odom_cov.inverse();
-  covariance<2> sensor_cov = covariance<2>::Zero();
-  sensor_cov << SLAM_VAR, 0,
-                0, SLAM_VAR;
-  covariance<2> sensor_cov_inv = sensor_cov.inverse();
-  Graph graph;
-  for (int t=0; t < T+1; t++) {
-    for (int i = 0; i < nLandmarks; i++) {
-      point_t l = readings[(size_t)t][(size_t)i];
-      if (l(2) == 0.0) continue; // Landmark wasn't visible
-      measurement<2> lm = measurement<2> { l(0), l(1) };
-      graph.add(new LandmarkFactor2D(3*T+2*i, 3*(t-1), sensor_cov_inv, lm));
-    }
-    if (t>0) {
-      int t2 = 3*(t-1);
-      int t1 = 3*(t-2);
-      measurement<3> om2 = x0.block(t2,0,3,1);
-      measurement<3> om1 = measurement<3>::Zero();
-      if (t1 >= 0)
-        om1 = x0.block(t1,0,3,1);
-      pose_t diff = toPose(toTransform(om2) * toTransform(om1).inverse(), 0.0);
-      graph.add(new OdomFactor2D(t2, t1, odom_cov_inv, diff));
-    }
-  }
-  graph.solve(x0);
-  return graph;
-}
-
 int main() {
-  collectDataAndRunSLAM(&smooth);
+  collectDataAndRunSLAM();
   return 0;
 }

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS=-pedantic-errors -Wall -Weffc++ -Wextra -Wsign-conversion
 SIMULATOR_DEPS=utils.o graphics.o world.o
 GRAPH_DEPS=graph.o factors.o
 SFML=-lsfml-graphics -lsfml-window -lsfml-system -pthread
-SLAM_DEPS=$(GRAPH_DEPS) $(SIMULATOR_DEPS) print_results.o slam_utils.o
+SLAM_DEPS=$(GRAPH_DEPS) $(SIMULATOR_DEPS) print_results.o slam_utils.o friendly_graph.o
 NAV_DEPS=$(SIMULATOR_DEPS) plan.o search.o simulator_world.o
 
 target: 2D 1D nav test_graph

--- a/constants.h
+++ b/constants.h
@@ -28,7 +28,7 @@ const double WHEEL_STD = 0.04; // std in meters for 1 meter distance traveled
 /* Graphics */
 
 const int DEFAULT_WINDOW_WIDTH_PX = 600;
-const double DEFAULT_WINDOW_WIDTH = 2*LANDMARK_MAX_RANGE; // m
+const double DEFAULT_WINDOW_WIDTH = 30.0; // m
 const double DEFAULT_WINDOW_CENTER_X = ROBOT_LENGTH*10; // m
 const double DEFAULT_WINDOW_CENTER_Y = 2.0; // m
 

--- a/factors.cpp
+++ b/factors.cpp
@@ -40,7 +40,8 @@ jacobian<1> GPSFactor::jf(const values &x) {
   return j;
 }
 
-LandmarkFactor2D::LandmarkFactor2D(int lmPose, int sensorPose, covariance<2> &sigma_inv, measurement<2> m) : Factor<2>(
+LandmarkFactor2D::LandmarkFactor2D(int lmPose, int sensorPose,
+      const covariance<2> &sigma_inv, const measurement<2> m) : Factor<2>(
     sigma_inv, m
     ), _lmPose(lmPose), _sensorPose(sensorPose) { }
 
@@ -82,7 +83,8 @@ jacobian<2> LandmarkFactor2D::jf(const values &x) {
 
 // This is identical to LandmarkFactor2D except for one extra measurement (an angle difference).
 // TODO figure out how to remove all the duplicate code.
-OdomFactor2D::OdomFactor2D(int pose2, int pose1, covariance<3> &sigma_inv, measurement<3> m) : Factor<3>(
+OdomFactor2D::OdomFactor2D(int pose2, int pose1,
+      const covariance<3> &sigma_inv, const measurement<3> m) : Factor<3>(
     sigma_inv, m
     ), _pose2(pose2), _pose1(pose1) { }
 

--- a/factors.h
+++ b/factors.h
@@ -64,7 +64,7 @@ class LandmarkFactor2D : public Factor<2> {
   int _lmPose, _sensorPose;
 
 public:
-  LandmarkFactor2D(int lmPose, int sensorPose, covariance<2> &sigma_inv, measurement<2> m);
+  LandmarkFactor2D(int lmPose, int sensorPose, const covariance<2> &sigma_inv, const measurement<2> m);
   virtual measurement<2> f(const values &x);
   virtual jacobian<2> jf(const values &x);
 };
@@ -73,7 +73,7 @@ class OdomFactor2D : public Factor<3> {
   int _pose2, _pose1;
 
 public:
-  OdomFactor2D(int pose2, int pose1, covariance<3> &sigma_inv, measurement<3> m);
+  OdomFactor2D(int pose2, int pose1, const covariance<3> &sigma_inv, const measurement<3> m);
   virtual measurement<3> f(const values &x);
   virtual jacobian<3> jf(const values &x);
 };

--- a/friendly_graph.cpp
+++ b/friendly_graph.cpp
@@ -74,7 +74,6 @@ void FriendlyGraph::addOdomMeasurement(int pose2_id, int pose1_id,
   pose_t pose1_est = getPoseEstimate(pose1_id);
   transform_t new_pose_tf = rel_tf * toTransform(pose1_est);
   pose_t pose2_est = toPose(new_pose_tf, pose1_est(2));
-  printf("Setting pose2 estimate %f %f %f\n", pose2_est(0), pose2_est(1), pose2_est(2));
   _current_guess.block(poseIdx(pose2_id),0,POSE_SIZE,1) = pose2_est;
 }
 

--- a/friendly_graph.cpp
+++ b/friendly_graph.cpp
@@ -1,0 +1,100 @@
+
+#include "friendly_graph.h"
+#include "utils.h"
+#include "constants.h"
+
+#include <iostream>
+#include <Eigen/Core>
+#include <Eigen/LU>
+#include <vector>
+
+using namespace NavSim;
+
+constexpr int LM_SIZE = 2;
+constexpr int POSE_SIZE = 3;
+
+FriendlyGraph::FriendlyGraph(int num_landmarks) :
+    _num_landmarks(num_landmarks), _num_poses(0), _current_guess(LM_SIZE*num_landmarks),
+    _odom_cov_inv(), _sensor_cov_inv(), _gps_cov_inv(), _graph()
+{
+  covariance<3> odom_cov = covariance<3>::Zero();
+  // TODO what are the right numbers here? Should y be correlated with theta?
+  odom_cov << SLAM_VAR, 0, 0,
+              0, SLAM_VAR, SLAM_VAR/2.0,
+              0, SLAM_VAR/2.0, SLAM_VAR;
+  _odom_cov_inv = odom_cov.inverse();
+  covariance<2> sensor_cov = covariance<2>::Zero();
+  sensor_cov << SLAM_VAR, 0,
+                0, SLAM_VAR;
+  _sensor_cov_inv = sensor_cov.inverse();
+  // GPS has no heading measurements
+  // which we represent using a large covariance
+  covariance<3> gps_cov = covariance<3>::Zero();
+  gps_cov << 3.0 * 3.0, 0, 0,
+             0, 3.0 * 3.0, 0,
+             0, 0, 50.0 * 50.0;
+  _gps_cov_inv = gps_cov.inverse();
+}
+
+void FriendlyGraph::incrementNumPoses() {
+    _num_poses++;
+    _current_guess.conservativeResize(_num_landmarks * LM_SIZE + _num_poses * POSE_SIZE);
+}
+
+int FriendlyGraph::poseIdx(int pose_id) {
+  if (pose_id == _num_poses) {
+    incrementNumPoses();
+  } else if (pose_id > _num_poses) {
+    printf("Error: skipped a pose id (given %d, current %d)\n", pose_id, _num_poses);
+    throw 1;
+  }
+  return _num_landmarks * LM_SIZE + pose_id * POSE_SIZE;
+}
+
+int FriendlyGraph::landmarkIdx(int lm_id) {
+  assert(lm_id < _num_landmarks);
+  return lm_id * LM_SIZE;
+}
+
+void FriendlyGraph::addGPSMeasurement(int pose_id, const transform_t &gps_tf) {
+  pose_t gps = toPose(gps_tf, 0); // heading doesn't matter
+  _graph.add(new OdomFactor2D(poseIdx(pose_id), -1, _gps_cov_inv, gps));
+  _current_guess.block(poseIdx(pose_id),0,POSE_SIZE,1) = gps;
+}
+
+void FriendlyGraph::addOdomMeasurement(int pose2_id, int pose1_id,
+    const transform_t &pose2_tf, const transform_t &pose1_tf) {
+  pose_t diff = toPose(pose2_tf * pose1_tf.inverse(), 0.0);
+  _graph.add(new OdomFactor2D(poseIdx(pose2_id), poseIdx(pose1_id), _odom_cov_inv, diff));
+}
+
+void FriendlyGraph::addLandmarkMeasurement(int pose_id, int lm_id, const point_t &bearing) {
+  measurement<2> lm = measurement<2> { bearing(0), bearing(1) };
+  _graph.add(new LandmarkFactor2D(landmarkIdx(lm_id), poseIdx(pose_id), _sensor_cov_inv, lm));
+}
+
+void FriendlyGraph::addLandmarkPrior(int lm_id, point_t location, double xy_std) {
+  covariance<2> prior_cov = covariance<2>::Zero();
+  prior_cov << xy_std * xy_std, 0,
+               0, xy_std * xy_std;
+  covariance<2> prior_cov_inv = prior_cov.inverse();
+  measurement<2> lm = measurement<2> { location(0), location(1) };
+  _graph.add(new LandmarkFactor2D(landmarkIdx(lm_id), -1, prior_cov_inv, lm));
+  _current_guess.block(landmarkIdx(lm_id),0,LM_SIZE,1) = lm;
+}
+
+void FriendlyGraph::addPosePrior(int pose_id, const transform_t &pose_tf,
+    double xy_std, double th_std) {
+  covariance<3> prior_cov = covariance<3>::Zero();
+  prior_cov << xy_std * xy_std, 0, 0,
+               0, xy_std * xy_std, 0,
+               0, 0, th_std * th_std;
+  covariance<3> prior_cov_inv = prior_cov.inverse();
+  pose_t pose = toPose(pose_tf, 0);
+  _graph.add(new OdomFactor2D(poseIdx(pose_id), -1, prior_cov_inv, pose));
+}
+
+void FriendlyGraph::solve() {
+  _graph.solve(_current_guess);
+  _current_guess = _graph.solution();
+}

--- a/friendly_graph.h
+++ b/friendly_graph.h
@@ -17,6 +17,7 @@ private:
   int poseIdx(int pose_id);
   int landmarkIdx(int lm_id);
   void incrementNumPoses();
+  pose_t getPoseEstimate(int pose_id);
 
 public:
   Graph _graph;

--- a/friendly_graph.h
+++ b/friendly_graph.h
@@ -1,0 +1,38 @@
+#ifndef FRIENDLY_GRAPH_H__
+#define FRIENDLY_GRAPH_H__
+
+#include "graph.h"
+#include "factors.h"
+#include "utils.h"
+
+class FriendlyGraph {
+private:
+  int _num_landmarks;
+  int _num_poses;
+
+  covariance<3> _odom_cov_inv;
+  covariance<2> _sensor_cov_inv;
+  covariance<3> _gps_cov_inv;
+
+  int poseIdx(int pose_id);
+  int landmarkIdx(int lm_id);
+  void incrementNumPoses();
+
+public:
+  Graph _graph;
+  values _current_guess;
+
+  FriendlyGraph(int num_landmarks);
+
+  void addGPSMeasurement(int pose_id, const transform_t &gps_tf);
+  void addOdomMeasurement(int pose2_id, int pose1_id,
+    const transform_t &pose2_tf, const transform_t &pose1_tf);
+  void addLandmarkMeasurement(int pose_id, int lm_id, const point_t &bearing);
+  void addLandmarkPrior(int lm_id, point_t location, double xy_std);
+  void addPosePrior(int pose_id, const transform_t &pose_tf,
+    double xy_std, double th_std);
+
+  void solve();
+};
+
+#endif

--- a/friendly_graph.h
+++ b/friendly_graph.h
@@ -9,6 +9,7 @@ class FriendlyGraph {
 private:
   int _num_landmarks;
   int _num_poses;
+  values _current_guess;
 
   covariance<3> _odom_cov_inv;
   covariance<2> _sensor_cov_inv;
@@ -17,11 +18,9 @@ private:
   int poseIdx(int pose_id);
   int landmarkIdx(int lm_id);
   void incrementNumPoses();
-  pose_t getPoseEstimate(int pose_id);
 
 public:
   Graph _graph;
-  values _current_guess;
 
   FriendlyGraph(int num_landmarks);
 
@@ -33,6 +32,7 @@ public:
   void addPosePrior(int pose_id, const transform_t &pose_tf,
     double xy_std, double th_std);
 
+  pose_t getPoseEstimate(int pose_id);
   void solve();
 };
 

--- a/print_results.cpp
+++ b/print_results.cpp
@@ -28,10 +28,9 @@ void printRange(Graph &g, values ground_truth, int start, int end, int size) {
   }
 }
 
-points_t toLandmarks(const values &x, int start, int lm_size) {
-  int N = x.size();
+points_t toLandmarks(const values &x, int start, int lm_size, int L) {
   points_t lms({});
-  for (int i = start; i < N; i += lm_size) {
+  for (int i = start; i < start + L*lm_size; i += lm_size) {
     point_t lm ({0, 0, 1});
     lm.topRows(lm_size) = x.block(i, 0, lm_size, 1);
     lms.push_back(lm);
@@ -39,10 +38,9 @@ points_t toLandmarks(const values &x, int start, int lm_size) {
   return lms;
 }
 
-trajectory_t toTraj(const values &x, int pose_size, int T) {
+trajectory_t toTraj(const values &x, int start, int pose_size, int T) {
   trajectory_t tfs({});
-  tfs.push_back(toTransformRotateFirst(0, 0, 0));
-  for (int i = 0; i < T*pose_size; i += pose_size) {
+  for (int i = start; i <= start+T*pose_size; i += pose_size) {
     if (pose_size == 3) { // 2D
       tfs.push_back(toTransformRotateFirst(0, 0, x(i+2)) * toTransformRotateFirst(x(i), x(i+1), 0));
     } else { // 1D
@@ -59,26 +57,27 @@ void printResults(MyWindow &window, Graph &g, const trajectory_t &true_trajector
     lm_size = 2;
   }
   int T = true_trajectory.size() - 1;
+  int L = true_landmarks.size();
 
   std::cout.precision(3);
   std::cout << std::fixed;
 
   std::cout << std::showpos;
   values ground_truth = toVector(true_trajectory, true_landmarks);
-  std::cout << std::endl << "Trajectory:" << std::endl;
-  printRange(g, ground_truth, 0, pose_size*T, pose_size);
   std::cout << std::endl << "Landmark locations:" << std::endl;
-  printRange(g, ground_truth, pose_size*T, ground_truth.size(), lm_size);
+  printRange(g, ground_truth, 0, lm_size*L, lm_size);
+  std::cout << std::endl << "Trajectory:" << std::endl;
+  printRange(g, ground_truth, lm_size*L, ground_truth.size(), pose_size);
   std::cout << std::noshowpos;
 
-  std::cout << std::endl << "Odom error: " << (ground_truth-g.x0()).norm() << std::endl;
+  std::cout << std::endl << "Initial error: " << (ground_truth-g.x0()).norm() << std::endl;
   std::cout << "Smoothed error: " << (ground_truth-g.solution()).norm() << std::endl;
-  std::cout << "Odom potential: " << g.eval(g.x0()) << std::endl;
+  std::cout << "Initial potential: " << g.eval(g.x0()) << std::endl;
   std::cout << "Smoothed potential: " << g.eval(g.solution()) << std::endl;
   std::cout << "Ground truth potential: " << g.eval(ground_truth) << std::endl;
 
-  trajectory_t smoothed_traj = toTraj(g.solution(), pose_size, T);
-  points_t smoothed_lms = toLandmarks(g.solution(), T*pose_size, lm_size);
+  points_t smoothed_lms = toLandmarks(g.solution(), 0, lm_size, L);
+  trajectory_t smoothed_traj = toTraj(g.solution(), lm_size*L, pose_size, T);
   window.drawPoints(smoothed_lms, sf::Color::Green, 3);
   window.drawTraj(smoothed_traj, sf::Color::Green);
   window.display();

--- a/print_results.cpp
+++ b/print_results.cpp
@@ -70,6 +70,9 @@ void printResults(MyWindow &window, Graph &g, const trajectory_t &true_trajector
   printRange(g, ground_truth, lm_size*L, ground_truth.size(), pose_size);
   std::cout << std::noshowpos;
 
+  // TODO maybe we should compute error in a more sophisticated way?
+  // E.g. we don't really care about absolute landmark location so much as
+  // location relative to the robot.
   std::cout << std::endl << "Initial error: " << (ground_truth-g.x0()).norm() << std::endl;
   std::cout << "Smoothed error: " << (ground_truth-g.solution()).norm() << std::endl;
   std::cout << "Initial potential: " << g.eval(g.x0()) << std::endl;

--- a/slam_utils.cpp
+++ b/slam_utils.cpp
@@ -61,10 +61,10 @@ void collectDataAndRunSLAM() {
   w.start();
   transform_t prev_odom = w.readOdom();
   for (int pose_id = 0; pose_id < T+1; pose_id++) {
-    points_t lm_readings = w.readLandmarks();
-    landmark_readings.push_back(lm_readings);
+    points_t lm_reading = w.readLandmarks();
+    landmark_readings.push_back(lm_reading);
     for (int lm_id = 0; lm_id < L; lm_id++) {
-      point_t lm = lm_readings[lm_id];
+      point_t lm = lm_reading[(size_t)lm_id];
       if (lm(2) != 0.0) fg.addLandmarkMeasurement(pose_id, lm_id, lm);
     }
     if (pose_id > 0) {
@@ -72,10 +72,9 @@ void collectDataAndRunSLAM() {
       fg.addOdomMeasurement(pose_id, pose_id-1, odom, prev_odom);
       prev_odom = odom;
     }
-    odom_traj.push_back(prev_odom);
+    odom_traj.push_back(toTransform(fg.getPoseEstimate(pose_id)));
     transform_t gps = w.readGPS();
     if (gps.norm() != 0.0) {
-      printf("Got a true GPS reading\n");
       gps_traj.push_back(gps);
       fg.addGPSMeasurement(pose_id, gps);
     }
@@ -101,7 +100,7 @@ void collectDataAndRunSLAM() {
   window.drawPoints(w.trueLandmarks(), sf::Color::Black, 3);
 
   fg.solve();
-  Graph g = fg._graph;
+  Graph &g = fg._graph;
   printResults(window, g, ground_truth, w.trueLandmarks());
 }
 

--- a/slam_utils.cpp
+++ b/slam_utils.cpp
@@ -6,6 +6,7 @@
 #include "slam_utils.h"
 #include "utils.h"
 #include "graph.h"
+#include "friendly_graph.h"
 #include "graphics.h"
 #include "world.h"
 #include "constants.h"
@@ -20,37 +21,65 @@ values toVector(const trajectory_t &traj, const points_t &r) {
     pose_size = 3;
     lm_size = 2;
   }
-  // We don't include a variable for T=0 since we *define* that to be the origin
-  int N = pose_size*T+lm_size*L;
+  int N = lm_size*L + pose_size*(T+1);
   values v = values::Zero(N);
   double prev_theta = 0.;
-  for (int i = 0; i < T; i++) {
-    transform_t trf = traj[(size_t)i+1];
-    pose_t p = toPose(trf, prev_theta);
-    v.block(pose_size*i,0,pose_size,1) = p.topRows(pose_size);
-    prev_theta = p(2);
-  }
   for (int i = 0; i < L; i++) {
-    v.block(pose_size*T+lm_size*i, 0, lm_size, 1) = r[(size_t)i].topRows(lm_size);
+    v.block(lm_size*i, 0, lm_size, 1) = r[(size_t)i].topRows(lm_size);
+  }
+  for (int i = 0; i <= T; i++) {
+    transform_t trf = traj[(size_t)i];
+    pose_t p = toPose(trf, prev_theta);
+    v.block(lm_size*L + pose_size*i,0,pose_size,1) = p.topRows(pose_size);
+    prev_theta = p(2);
   }
   return v;
 }
 
-void collectDataAndRunSLAM(Graph (*smooth)(const values &x0, const traj_points_t &readings)) {
+void collectDataAndRunSLAM() {
   constexpr int T = 10;
+  int L = 6;
+  int N = 3*(T+1) + 2*L;
+  values v = values::Zero(N);
 
   traj_points_t landmark_readings({});
   trajectory_t ground_truth({});
   trajectory_t odom({});
+  trajectory_t gps_traj({});
+
+
+  FriendlyGraph fg(L);
+  fg.addPosePrior(0, toTransform({0,0,0}), 20.0, 10.0); // uninformative prior
+  for (int l = 0; l < L; l++) {
+    point_t location({0,0,1});
+    fg.addLandmarkPrior(l, location, 20.0); // uninformative prior
+  }
 
   World w;
   w.addDefaultLandmarks();
   w.start();
-  for (int i = 0; i < T+1; i++) {
-    landmark_readings.push_back(w.readLandmarks());
-    odom.push_back(w.readOdom());
+  transform_t prev_odom = w.readOdom();
+  for (int pose_id = 0; pose_id < T+1; pose_id++) {
+    points_t lm_readings = w.readLandmarks();
+    landmark_readings.push_back(lm_readings);
+    for (int lm_id = 0; lm_id < L; lm_id++) {
+      point_t lm = lm_readings[lm_id];
+      if (lm(2) != 0.0) fg.addLandmarkMeasurement(pose_id, lm_id, lm);
+    }
+    if (pose_id > 0) {
+      transform_t odom = w.readOdom();
+      fg.addOdomMeasurement(pose_id, pose_id-1, odom, prev_odom);
+      prev_odom = odom;
+    }
+    odom.push_back(prev_odom);
+    transform_t gps = w.readGPS();
+    if (gps.norm() != 0.0) {
+      fg.addGPSMeasurement(pose_id, gps);
+    }
+    gps_traj.push_back(gps);
+
     ground_truth.push_back(w.readTrueTransform());
-    if (i == 0) w.setCmdVel(0.0, ROBOT_LENGTH*8);
+    if (pose_id == 0) w.setCmdVel(0.0, ROBOT_LENGTH*8);
     usleep(200 * 1000);
   }
   w.setCmdVel(0.0, 0.0);
@@ -67,8 +96,8 @@ void collectDataAndRunSLAM(Graph (*smooth)(const values &x0, const traj_points_t
   window.drawTraj(ground_truth, sf::Color::Black);
   window.drawPoints(w.trueLandmarks(), sf::Color::Black, 3);
 
-  values x0 = toVector(odom, landmark_readings[0]);
-  Graph g = smooth(x0, landmark_readings);
+  fg.solve();
+  Graph g = fg._graph;
   printResults(window, g, ground_truth, w.trueLandmarks());
 }
 

--- a/slam_utils.h
+++ b/slam_utils.h
@@ -6,6 +6,7 @@
 #include "graph.h"
 
 values toVector(const trajectory_t &traj, const points_t &r);
-void collectDataAndRunSLAM(Graph (*smooth)(const values &x0, const traj_points_t &readings));
+//void collectDataAndRunSLAM(Graph (*smooth)(const values &x0, const traj_points_t &readings));
+void collectDataAndRunSLAM();
 
 #endif

--- a/world.cpp
+++ b/world.cpp
@@ -21,7 +21,8 @@ World::World() : obstacles_({}), landmarks_({}),
                     current_transform_truth_(toTransform({0,0,0})),
                     current_transform_odom_(toTransform({0,0,0})),
                     spin_thread_(), done_(false),
-                    legs_({}), window_("Simulator visualization")
+                    legs_({}), window_("Simulator visualization"),
+                    last_gps_reading_()
 {
 }
 
@@ -158,7 +159,7 @@ void World::addDefaultLandmarks() {
 void World::spinSim() {
   const double SIM_HZ = 30.;
   const double dt = 1/SIM_HZ;
-  struct timeval tp0, tp_start;
+  struct timeval tp_start;
   while (!done_) {
     gettimeofday(&tp_start, NULL);
     int c = 0;

--- a/world.cpp
+++ b/world.cpp
@@ -18,7 +18,7 @@ const sf::Color LANDMARK_COLOR(0,0,255);
 
 World::World() : obstacles_({}), landmarks_({}),
                     cmd_vel_x_(0), cmd_vel_theta_(0),
-                    current_transform_truth_(toTransform({0,0,0})),
+                    current_transform_truth_(toTransform({15,0,M_PI})),
                     current_transform_odom_(toTransform({0,0,0})),
                     spin_thread_(), done_(false),
                     legs_({}), window_("Simulator visualization"),


### PR DESCRIPTION
None of this code is actually used in our on-rover programs, yet.

Introduces a new class FriendlyGraph that's much more intuitive for
adding different kinds of factors.

Adds GPS measurements to the 2D_slam example.

The starting pose is now itself an optimization variable, rather than
being defined to be (0,0,0). This is so that all variables are now in
the GPS frame.

Currently 1D_slam will not compile; I am sorry.