### PR TITLE
Implement pose graph trimming

### DIFF
--- a/factors.h
+++ b/factors.h
@@ -48,6 +48,7 @@ public:
   OdomFactor(int idx1, int idx2, double sigma, double m);
   virtual measurement<1> f(const values &x);
   virtual jacobian<1> jf(const values &x);
+  virtual bool shiftIndices(int poseSize, int firstPoseIdx);
 };
 
 
@@ -58,6 +59,7 @@ public:
   GPSFactor(int idx, double sigma, double m);
   virtual measurement<1> f(const values &x);
   virtual jacobian<1> jf(const values &x);
+  virtual bool shiftIndices(int poseSize, int firstPoseIdx);
 };
 
 class LandmarkFactor2D : public Factor<2> {
@@ -67,6 +69,7 @@ public:
   LandmarkFactor2D(int lmPose, int sensorPose, const covariance<2> &sigma_inv, const measurement<2> m);
   virtual measurement<2> f(const values &x);
   virtual jacobian<2> jf(const values &x);
+  virtual bool shiftIndices(int poseSize, int firstPoseIdx);
 };
 
 class OdomFactor2D : public Factor<3> {
@@ -76,6 +79,7 @@ public:
   OdomFactor2D(int pose2, int pose1, const covariance<3> &sigma_inv, const measurement<3> m);
   virtual measurement<3> f(const values &x);
   virtual jacobian<3> jf(const values &x);
+  virtual bool shiftIndices(int poseSize, int firstPoseIdx);
 };
 
 #endif

--- a/factors.h
+++ b/factors.h
@@ -22,9 +22,8 @@ public:
   Factor(const covariance<D> &sigma_inv, const measurement<D> &measurement) :
       _sigma_inv(sigma_inv), _measurement(measurement) {}
 
-  // To be implemented by subclasses
-  virtual measurement<D> f(const values &/*x*/) { assert("abstract f" && false); }
-  virtual jacobian<D> jf(const values &/*x*/) { assert("abstract jf" && false); }
+  virtual measurement<D> f(const values &/*x*/) = 0;
+  virtual jacobian<D> jf(const values &/*x*/) = 0;
 
   virtual double eval(const values &x) {
     measurement<D> diff = f(x) - _measurement;

--- a/friendly_graph.cpp
+++ b/friendly_graph.cpp
@@ -113,7 +113,7 @@ void FriendlyGraph::addOdomMeasurement(int pose2_id, int pose1_id,
   float ang_dist = ROBOT_WHEEL_BASE * diff(2) * 4;
   float noise_distance_sq = lin_dist*lin_dist + ang_dist*ang_dist;
   _graph.add(new OdomFactor2D(poseIdx(pose2_id), poseIdx(pose1_id),
-        noise_distance_sq * _odom_cov_inv, diff));
+        _odom_cov_inv / noise_distance_sq, diff));
   pose_t pose1_est = getPoseEstimate(pose1_id);
   transform_t new_pose_tf = rel_tf * toTransform(pose1_est);
   pose_t pose2_est = toPose(new_pose_tf, pose1_est(2));

--- a/friendly_graph.cpp
+++ b/friendly_graph.cpp
@@ -79,8 +79,10 @@ void FriendlyGraph::trimToMaxNumPoses() {
     values old_guess = _current_guess;
     printf("Trimming. Current uncertainty on base pose: %f %f %f\n",
         first_pose_cov(0,0), first_pose_cov(1,1), first_pose_cov(2,2));
-    double xy_std = first_pose_cov(0,0);
-    double th_std = first_pose_cov(2,2);
+    // TODO may want to redo this to use the full covariance, rather than just
+    // these first two numbers
+    double xy_std = sqrt(first_pose_cov(0,0));
+    double th_std = sqrt(first_pose_cov(2,2));
     _graph.shiftIndices(POSE_SIZE, poseIdx(_min_pose_id));
     _min_pose_id += 1;
     _current_guess.conservativeResize(nonincrementingPoseIdx(_max_pose_id));

--- a/friendly_graph.cpp
+++ b/friendly_graph.cpp
@@ -108,3 +108,26 @@ void FriendlyGraph::solve() {
   _graph.solve(_current_guess);
   _current_guess = _graph.solution();
 }
+
+points_t FriendlyGraph::getLandmarkLocations() {
+  points_t lms({});
+  for (int i = 0; i < _num_landmarks*LM_SIZE; i += LM_SIZE) {
+    point_t lm ({0, 0, 1});
+    lm.topRows(LM_SIZE) = _current_guess.block(i, 0, LM_SIZE, 1);
+    lms.push_back(lm);
+  }
+  return lms;
+}
+
+trajectory_t FriendlyGraph::getSmoothedTrajectory() {
+  const values &x = _current_guess;
+  trajectory_t tfs({});
+  for (int i = _num_landmarks*LM_SIZE; i < _num_landmarks*LM_SIZE+_num_poses*POSE_SIZE; i += POSE_SIZE) {
+    if (POSE_SIZE == 3) { // 2D
+      tfs.push_back(toTransformRotateFirst(0, 0, x(i+2)) * toTransformRotateFirst(x(i), x(i+1), 0));
+    } else { // 1D
+      tfs.push_back(toTransformRotateFirst(x(i), 0, 0));
+    }
+  }
+  return tfs;
+}

--- a/friendly_graph.cpp
+++ b/friendly_graph.cpp
@@ -82,8 +82,8 @@ void FriendlyGraph::trimToMaxNumPoses() {
     covariance<3> first_pose_cov = sol_cov.block(
         base_idx, base_idx, POSE_SIZE, POSE_SIZE);
     values old_guess = _current_guess;
-    printf("Trimming. Current uncertainty on base pose: %f %f %f\n",
-        sqrt(first_pose_cov(0,0)), sqrt(first_pose_cov(1,1)), sqrt(first_pose_cov(2,2)));
+    //printf("Trimming. Current uncertainty on base pose: %f %f %f\n",
+    //    sqrt(first_pose_cov(0,0)), sqrt(first_pose_cov(1,1)), sqrt(first_pose_cov(2,2)));
     _graph.shiftIndices(POSE_SIZE, poseIdx(_min_pose_id));
     _min_pose_id += 1;
     _current_guess.conservativeResize(nonincrementingPoseIdx(_max_pose_id));

--- a/friendly_graph.h
+++ b/friendly_graph.h
@@ -27,6 +27,14 @@ private:
 public:
   Graph _graph;
 
+  /* num_landmarks: Currently we require you to pre-specify how many landmarks
+   *                will be considered in the pose graph. TODO: Make it possible to
+   *                add more landmarks over time.
+   *
+   * max_num_poses: To prevent the pose graph from growing arbitrarily over time,
+   *                we automatically trim the oldest poses once we get enough newer ones.
+   *                This parameter specifies the maximum number of poses in the graph.
+   */
   FriendlyGraph(int num_landmarks, int max_num_poses);
 
   void addGPSMeasurement(int pose_id, const transform_t &gps_tf);
@@ -39,6 +47,9 @@ public:
   pose_t getPoseEstimate(int pose_id);
   void solve();
   points_t getLandmarkLocations();
+  /* This method will return the smoothed trajectory (assuming you've already called
+   * `solve()`). Note that the length of this trajectory will be at most `max_num_poses`
+   * (the oldest poses are discarded). */
   trajectory_t getSmoothedTrajectory();
   int getMaxNumPoses() const;
 

--- a/friendly_graph.h
+++ b/friendly_graph.h
@@ -34,6 +34,8 @@ public:
 
   pose_t getPoseEstimate(int pose_id);
   void solve();
+  points_t getLandmarkLocations();
+  trajectory_t getSmoothedTrajectory();
 };
 
 #endif

--- a/friendly_graph.h
+++ b/friendly_graph.h
@@ -34,8 +34,7 @@ public:
     const transform_t &pose2_tf, const transform_t &pose1_tf);
   void addLandmarkMeasurement(int pose_id, int lm_id, const point_t &bearing);
   void addLandmarkPrior(int lm_id, point_t location, double xy_std);
-  void addPosePrior(int pose_id, const transform_t &pose_tf,
-    double xy_std, double th_std);
+  void addPosePrior(int pose_id, const transform_t &pose_tf, covariance<3> &cov);
 
   pose_t getPoseEstimate(int pose_id);
   void solve();

--- a/friendly_graph.h
+++ b/friendly_graph.h
@@ -41,6 +41,7 @@ public:
   void solve();
   points_t getLandmarkLocations();
   trajectory_t getSmoothedTrajectory();
+  int getMaxNumPoses() const;
 
 };
 

--- a/friendly_graph.h
+++ b/friendly_graph.h
@@ -8,21 +8,26 @@
 class FriendlyGraph {
 private:
   int _num_landmarks;
-  int _num_poses;
+  int _max_pose_id;
+  int _min_pose_id;
+  int _max_num_poses;
   values _current_guess;
 
   covariance<3> _odom_cov_inv;
   covariance<2> _sensor_cov_inv;
   covariance<3> _gps_cov_inv;
 
+  int nonincrementingPoseIdx(int pose_id);
   int poseIdx(int pose_id);
   int landmarkIdx(int lm_id);
+  int numPoses();
   void incrementNumPoses();
+  void trimToMaxNumPoses();
 
 public:
   Graph _graph;
 
-  FriendlyGraph(int num_landmarks);
+  FriendlyGraph(int num_landmarks, int max_num_poses);
 
   void addGPSMeasurement(int pose_id, const transform_t &gps_tf);
   void addOdomMeasurement(int pose2_id, int pose1_id,
@@ -36,6 +41,7 @@ public:
   void solve();
   points_t getLandmarkLocations();
   trajectory_t getSmoothedTrajectory();
+
 };
 
 #endif

--- a/graph.cpp
+++ b/graph.cpp
@@ -6,18 +6,6 @@
 #include <vector>
 
 AbstractFactor::~AbstractFactor() {}
-double AbstractFactor::eval(const values &/*x*/) { assert("abstract eval" && false); }
-values AbstractFactor::gradient_at(const values &/*x*/) { assert("abstract grad" && false); }
-hessian AbstractFactor::hessian_at(const values &/*x*/) { assert("abstract hess" && false); }
-
-// Used to handle graph trimming so graph size does not grow arbitrarily.
-// Shifts all factor indices related to robot poses down by `poseSize`. If this
-// moves the index outside the range used for poses, return false.
-// If this returns false, the factor should be removed from the graph.
-bool AbstractFactor::shiftIndices(int /*poseSize*/, int /*firstPoseIdx*/) {
-  assert("abstract shift" && false);
-}
-
 
 Graph::Graph() : _x0(values::Zero(1)), _sol(values::Zero(1)), _sol_cov(hessian::Zero(1,1)),
     _factors({}) {}

--- a/graph.cpp
+++ b/graph.cpp
@@ -10,6 +10,14 @@ double AbstractFactor::eval(const values &/*x*/) { assert("abstract eval" && fal
 values AbstractFactor::gradient_at(const values &/*x*/) { assert("abstract grad" && false); }
 hessian AbstractFactor::hessian_at(const values &/*x*/) { assert("abstract hess" && false); }
 
+// Used to handle graph trimming so graph size does not grow arbitrarily.
+// Shifts all factor indices related to robot poses down by `poseSize`. If this
+// moves the index outside the range used for poses, return false.
+// If this returns false, the factor should be removed from the graph.
+bool AbstractFactor::shiftIndices(int /*poseSize*/, int /*firstPoseIdx*/) {
+  assert("abstract shift" && false);
+}
+
 
 Graph::Graph() : _x0(values::Zero(1)), _sol(values::Zero(1)), _sol_cov(hessian::Zero(1,1)),
     _factors({}) {}
@@ -78,3 +86,14 @@ hessian Graph::covariance() {
   return _sol_cov;
 }
 
+void Graph::shiftIndices(int poseSize, int firstPoseIdx) {
+  auto it = _factors.begin();
+  while (it != _factors.end()) {
+    if (!(*it)->shiftIndices(poseSize, firstPoseIdx)) {
+      free(*it);
+      it = _factors.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}

--- a/graph.h
+++ b/graph.h
@@ -11,11 +11,14 @@ using hessian = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
 class AbstractFactor {
 public:
   virtual ~AbstractFactor();
-  virtual double eval(const values &/*x*/);
-  virtual values gradient_at(const values &/*x*/);
-  virtual hessian hessian_at(const values &/*x*/);
-  // Used for trimming so the graph doesn't grow without bound
-  virtual bool shiftIndices(int poseSize, int firstPoseIdx);
+  virtual double eval(const values &/*x*/) = 0;
+  virtual values gradient_at(const values &/*x*/) = 0;
+  virtual hessian hessian_at(const values &/*x*/) = 0;
+  // Used to handle graph trimming so graph size does not grow arbitrarily.
+  // Shifts all factor indices related to robot poses down by `poseSize`. If this
+  // moves the index outside the range used for poses, return false.
+  // If this returns false, the factor should be removed from the graph.
+  virtual bool shiftIndices(int poseSize, int firstPoseIdx) = 0;
 };
 
 class Graph {

--- a/graph.h
+++ b/graph.h
@@ -14,6 +14,8 @@ public:
   virtual double eval(const values &/*x*/);
   virtual values gradient_at(const values &/*x*/);
   virtual hessian hessian_at(const values &/*x*/);
+  // Used for trimming so the graph doesn't grow without bound
+  virtual bool shiftIndices(int poseSize, int firstPoseIdx);
 };
 
 class Graph {
@@ -34,6 +36,7 @@ public:
   values x0();
   values solution();
   hessian covariance();
+  void shiftIndices(int poseSize, int firstPoseIdx);
 };
 
 #endif

--- a/print_results.cpp
+++ b/print_results.cpp
@@ -1,6 +1,7 @@
 
 #include <iostream>
 #include <unistd.h>
+#include "print_results.h"
 #include "graph.h"
 #include "slam_utils.h"
 #include "graphics.h"
@@ -28,35 +29,13 @@ void printRange(Graph &g, values ground_truth, int start, int end, int size) {
   }
 }
 
-points_t toLandmarks(const values &x, int start, int lm_size, int L) {
-  points_t lms({});
-  for (int i = start; i < start + L*lm_size; i += lm_size) {
-    point_t lm ({0, 0, 1});
-    lm.topRows(lm_size) = x.block(i, 0, lm_size, 1);
-    lms.push_back(lm);
-  }
-  return lms;
-}
-
-trajectory_t toTraj(const values &x, int start, int pose_size, int T) {
-  trajectory_t tfs({});
-  for (int i = start; i <= start+T*pose_size; i += pose_size) {
-    if (pose_size == 3) { // 2D
-      tfs.push_back(toTransformRotateFirst(0, 0, x(i+2)) * toTransformRotateFirst(x(i), x(i+1), 0));
-    } else { // 1D
-      tfs.push_back(toTransformRotateFirst(x(i), 0, 0));
-    }
-  }
-  return tfs;
-}
-
-void printResults(MyWindow &window, Graph &g, const trajectory_t &true_trajectory, const points_t &true_landmarks) {
+void printResults(MyWindow &window, FriendlyGraph &fg, const trajectory_t &true_trajectory, const points_t &true_landmarks) {
+  Graph &g = fg._graph;
   int pose_size(1), lm_size(1);
   if (IS_2D) {
     pose_size = 3;
     lm_size = 2;
   }
-  int T = true_trajectory.size() - 1;
   int L = true_landmarks.size();
 
   std::cout.precision(3);
@@ -79,8 +58,8 @@ void printResults(MyWindow &window, Graph &g, const trajectory_t &true_trajector
   std::cout << "Smoothed potential: " << g.eval(g.solution()) << std::endl;
   std::cout << "Ground truth potential: " << g.eval(ground_truth) << std::endl;
 
-  points_t smoothed_lms = toLandmarks(g.solution(), 0, lm_size, L);
-  trajectory_t smoothed_traj = toTraj(g.solution(), lm_size*L, pose_size, T);
+  points_t smoothed_lms = fg.getLandmarkLocations();
+  trajectory_t smoothed_traj = fg.getSmoothedTrajectory();
   window.drawPoints(smoothed_lms, sf::Color::Green, 3);
   window.drawTraj(smoothed_traj, sf::Color::Green);
   window.display();

--- a/print_results.cpp
+++ b/print_results.cpp
@@ -29,7 +29,9 @@ void printRange(Graph &g, values ground_truth, int start, int end, int size) {
   }
 }
 
-void printResults(MyWindow &window, FriendlyGraph &fg, const trajectory_t &true_trajectory, const points_t &true_landmarks) {
+void printResults(MyWindow &window, FriendlyGraph &fg,
+    const trajectory_t &true_trajectory, const points_t &true_landmarks,
+    const trajectory_t &odom_trajectory, const points_t &prior_landmarks) {
   Graph &g = fg._graph;
   int pose_size(1), lm_size(1);
   if (IS_2D) {
@@ -42,7 +44,8 @@ void printResults(MyWindow &window, FriendlyGraph &fg, const trajectory_t &true_
   std::cout << std::fixed;
 
   std::cout << std::showpos;
-  values ground_truth = toVector(true_trajectory, true_landmarks);
+  values ground_truth = toVector(true_trajectory, true_landmarks, fg.getMaxNumPoses());
+  values x0 = toVector(odom_trajectory, prior_landmarks, fg.getMaxNumPoses());
   std::cout << std::endl << "Landmark locations:" << std::endl;
   printRange(g, ground_truth, 0, lm_size*L, lm_size);
   std::cout << std::endl << "Trajectory:" << std::endl;
@@ -52,9 +55,9 @@ void printResults(MyWindow &window, FriendlyGraph &fg, const trajectory_t &true_
   // TODO maybe we should compute error in a more sophisticated way?
   // E.g. we don't really care about absolute landmark location so much as
   // location relative to the robot.
-  std::cout << std::endl << "Initial error: " << (ground_truth-g.x0()).norm() << std::endl;
+  std::cout << std::endl << "Initial error: " << (ground_truth-x0).norm() << std::endl;
   std::cout << "Smoothed error: " << (ground_truth-g.solution()).norm() << std::endl;
-  std::cout << "Initial potential: " << g.eval(g.x0()) << std::endl;
+  std::cout << "Initial potential: " << g.eval(x0) << std::endl;
   std::cout << "Smoothed potential: " << g.eval(g.solution()) << std::endl;
   std::cout << "Ground truth potential: " << g.eval(ground_truth) << std::endl;
 

--- a/print_results.cpp
+++ b/print_results.cpp
@@ -44,8 +44,11 @@ void printResults(MyWindow &window, FriendlyGraph &fg,
   std::cout << std::fixed;
 
   std::cout << std::showpos;
-  values ground_truth = toVector(true_trajectory, true_landmarks, fg.getMaxNumPoses());
-  values x0 = toVector(odom_trajectory, prior_landmarks, fg.getMaxNumPoses());
+  double base_pose_theta = g.solution()(lm_size*L + 2);
+  values ground_truth = toVector(true_trajectory, true_landmarks,
+      fg.getMaxNumPoses(), base_pose_theta);
+  values x0 = toVector(odom_trajectory, prior_landmarks,
+      fg.getMaxNumPoses(), base_pose_theta);
   std::cout << std::endl << "Landmark locations:" << std::endl;
   printRange(g, ground_truth, 0, lm_size*L, lm_size);
   std::cout << std::endl << "Trajectory:" << std::endl;

--- a/print_results.h
+++ b/print_results.h
@@ -2,10 +2,10 @@
 #ifndef PRINT_RESULTS_H
 #define PRINT_RESULTS_H
 
-#include "graph.h"
+#include "friendly_graph.h"
 #include "utils.h"
 #include "graphics.h"
 
-void printResults(MyWindow &window, Graph &g, const trajectory_t &true_trajectory, const points_t &true_landmarks);
+void printResults(MyWindow &window, FriendlyGraph &fg, const trajectory_t &true_trajectory, const points_t &true_landmarks);
 
 #endif

--- a/print_results.h
+++ b/print_results.h
@@ -6,6 +6,8 @@
 #include "utils.h"
 #include "graphics.h"
 
-void printResults(MyWindow &window, FriendlyGraph &fg, const trajectory_t &true_trajectory, const points_t &true_landmarks);
+void printResults(MyWindow &window, FriendlyGraph &fg,
+    const trajectory_t &true_trajectory, const points_t &true_landmarks,
+    const trajectory_t &odom_trajectory, const points_t &prior_landmarks);
 
 #endif

--- a/slam_utils.cpp
+++ b/slam_utils.cpp
@@ -13,7 +13,7 @@
 
 using namespace NavSim;
 
-values toVector(const trajectory_t &traj, const points_t &r, int max_num_poses) {
+values toVector(const trajectory_t &traj, const points_t &r, int max_num_poses, double prev_theta) {
   int num_extra_poses = (int) traj.size() - max_num_poses;
   int L = (int) r.size();
   int pose_size(1), lm_size(1);
@@ -24,7 +24,6 @@ values toVector(const trajectory_t &traj, const points_t &r, int max_num_poses) 
   int N = lm_size*L + pose_size*max_num_poses;
   values v = values::Zero(N);
   printf("Vectorizing trajectory and landmarks to dimension %ld\n", v.size());
-  double prev_theta = 0.;
   for (int i = 0; i < L; i++) {
     v.block(lm_size*i, 0, lm_size, 1) = r[(size_t)i].topRows(lm_size);
   }

--- a/slam_utils.cpp
+++ b/slam_utils.cpp
@@ -100,7 +100,6 @@ void collectDataAndRunSLAM() {
   window.drawPoints(w.trueLandmarks(), sf::Color::Black, 3);
 
   fg.solve();
-  Graph &g = fg._graph;
-  printResults(window, g, ground_truth, w.trueLandmarks());
+  printResults(window, fg, ground_truth, w.trueLandmarks());
 }
 

--- a/slam_utils.cpp
+++ b/slam_utils.cpp
@@ -13,22 +13,23 @@
 
 using namespace NavSim;
 
-values toVector(const trajectory_t &traj, const points_t &r) {
-  int T = (int) traj.size()-1;
+values toVector(const trajectory_t &traj, const points_t &r, int max_num_poses) {
+  int num_extra_poses = (int) traj.size() - max_num_poses;
   int L = (int) r.size();
   int pose_size(1), lm_size(1);
   if (IS_2D) {
     pose_size = 3;
     lm_size = 2;
   }
-  int N = lm_size*L + pose_size*(T+1);
+  int N = lm_size*L + pose_size*max_num_poses;
   values v = values::Zero(N);
+  printf("Vectorizing trajectory and landmarks to dimension %ld\n", v.size());
   double prev_theta = 0.;
   for (int i = 0; i < L; i++) {
     v.block(lm_size*i, 0, lm_size, 1) = r[(size_t)i].topRows(lm_size);
   }
-  for (int i = 0; i <= T; i++) {
-    transform_t trf = traj[(size_t)i];
+  for (int i = 0; i < max_num_poses; i++) {
+    transform_t trf = traj[(size_t)(i+num_extra_poses)];
     pose_t p = toPose(trf, prev_theta);
     v.block(lm_size*L + pose_size*i,0,pose_size,1) = p.topRows(pose_size);
     prev_theta = p(2);
@@ -37,10 +38,15 @@ values toVector(const trajectory_t &traj, const points_t &r) {
 }
 
 void collectDataAndRunSLAM() {
-  constexpr int T = 10;
-  int L = 6;
-  int N = 3*(T+1) + 2*L;
-  values v = values::Zero(N);
+  constexpr int T = 30;
+  points_t prior_landmarks({
+      {0,0,1},
+      {0,0,1},
+      {0,0,1},
+      {0,0,1},
+      {0,0,1},
+      {0,0,1}});
+  int L = (int)prior_landmarks.size();
 
   traj_points_t landmark_readings({});
   trajectory_t ground_truth({});
@@ -48,6 +54,7 @@ void collectDataAndRunSLAM() {
   trajectory_t gps_traj({});
 
   transform_t start_pose_guess = toTransform({13,-1,M_PI*2/3});
+  transform_t odom_accumulated_guess = start_pose_guess;
 
   FriendlyGraph fg(L, 10);
   fg.addPosePrior(0, start_pose_guess, 3.0, 1.0); // informed prior
@@ -70,9 +77,10 @@ void collectDataAndRunSLAM() {
     if (pose_id > 0) {
       transform_t odom = w.readOdom();
       fg.addOdomMeasurement(pose_id, pose_id-1, odom, prev_odom);
+      odom_accumulated_guess = odom * prev_odom.inverse() * odom_accumulated_guess;
       prev_odom = odom;
     }
-    odom_traj.push_back(toTransform(fg.getPoseEstimate(pose_id)));
+    odom_traj.push_back(odom_accumulated_guess);
     transform_t gps = w.readGPS();
     if (gps.norm() != 0.0) {
       gps_traj.push_back(gps);
@@ -81,6 +89,7 @@ void collectDataAndRunSLAM() {
 
     ground_truth.push_back(w.readTrueTransform());
     if (pose_id == 0) w.setCmdVel(0.0, ROBOT_LENGTH);
+    fg.solve();
     usleep(500 * 1000);
   }
   w.setCmdVel(0.0, 0.0);
@@ -99,7 +108,6 @@ void collectDataAndRunSLAM() {
   window.drawTraj(ground_truth, sf::Color::Black);
   window.drawPoints(w.trueLandmarks(), sf::Color::Black, 3);
 
-  fg.solve();
-  printResults(window, fg, ground_truth, w.trueLandmarks());
+  printResults(window, fg, ground_truth, w.trueLandmarks(), odom_traj, prior_landmarks);
 }
 

--- a/slam_utils.cpp
+++ b/slam_utils.cpp
@@ -37,7 +37,7 @@ values toVector(const trajectory_t &traj, const points_t &r, int max_num_poses, 
 }
 
 void collectDataAndRunSLAM() {
-  constexpr int T = 30;
+  constexpr int T = 20;
   points_t prior_landmarks({
       {0,0,1},
       {0,0,1},
@@ -95,7 +95,9 @@ void collectDataAndRunSLAM() {
     ground_truth.push_back(w.readTrueTransform());
     if (pose_id == 0) w.setCmdVel(0.0, ROBOT_LENGTH);
     fg.solve();
-    usleep(500 * 1000);
+    // Make this "relatively prime" with 1000 * 1000 to avoid randomness
+    // due to context switching. (Less randomness == good for debugging.)
+    usleep(498 * 1000);
   }
   w.setCmdVel(0.0, 0.0);
 

--- a/slam_utils.cpp
+++ b/slam_utils.cpp
@@ -49,7 +49,7 @@ void collectDataAndRunSLAM() {
 
   transform_t start_pose_guess = toTransform({13,-1,M_PI*2/3});
 
-  FriendlyGraph fg(L);
+  FriendlyGraph fg(L, 10);
   fg.addPosePrior(0, start_pose_guess, 3.0, 1.0); // informed prior
   for (int l = 0; l < L; l++) {
     point_t location({0,0,1});

--- a/slam_utils.cpp
+++ b/slam_utils.cpp
@@ -37,7 +37,7 @@ values toVector(const trajectory_t &traj, const points_t &r, int max_num_poses, 
 }
 
 void collectDataAndRunSLAM() {
-  constexpr int T = 20;
+  constexpr int T = 30;
   points_t prior_landmarks({
       {0,0,1},
       {0,0,1},

--- a/slam_utils.cpp
+++ b/slam_utils.cpp
@@ -56,7 +56,13 @@ void collectDataAndRunSLAM() {
   transform_t odom_accumulated_guess = start_pose_guess;
 
   FriendlyGraph fg(L, 10);
-  fg.addPosePrior(0, start_pose_guess, 3.0, 1.0); // informed prior
+  float prior_xy_std = 3.0;
+  float prior_th_std = 1.0;
+  covariance<3> prior_cov = covariance<3>::Zero();
+  prior_cov << prior_xy_std * prior_xy_std, 0, 0,
+               0, prior_xy_std * prior_xy_std, 0,
+               0, 0, prior_th_std * prior_th_std;
+  fg.addPosePrior(0, start_pose_guess, prior_cov); // informed prior
   for (int l = 0; l < L; l++) {
     point_t location({0,0,1});
     fg.addLandmarkPrior(l, location, 20.0); // uninformative prior

--- a/slam_utils.h
+++ b/slam_utils.h
@@ -5,7 +5,7 @@
 #include "utils.h"
 #include "graph.h"
 
-values toVector(const trajectory_t &traj, const points_t &r, int max_num_poses);
+values toVector(const trajectory_t &traj, const points_t &r, int max_num_poses, double prev_theta);
 //void collectDataAndRunSLAM(Graph (*smooth)(const values &x0, const traj_points_t &readings));
 void collectDataAndRunSLAM();
 

--- a/slam_utils.h
+++ b/slam_utils.h
@@ -5,7 +5,7 @@
 #include "utils.h"
 #include "graph.h"
 
-values toVector(const trajectory_t &traj, const points_t &r);
+values toVector(const trajectory_t &traj, const points_t &r, int max_num_poses);
 //void collectDataAndRunSLAM(Graph (*smooth)(const values &x0, const traj_points_t &readings));
 void collectDataAndRunSLAM();
 

--- a/utils.cpp
+++ b/utils.cpp
@@ -164,8 +164,8 @@ transform_t toTransform(const pose_t &pose) {
  * For programs with more threads, a more sophisticated solution will be necessary.
  */
 std::normal_distribution<double> stdn_dist(0.0, 1.0);
-//long seed = std::chrono::system_clock::now().time_since_epoch().count();
-long seed = 1626474823108702150;
+long seed = std::chrono::system_clock::now().time_since_epoch().count();
+//long seed = 1626474823108702150;
 std::default_random_engine main_generator(seed);
 std::default_random_engine spin_generator(seed);
 

--- a/utils.cpp
+++ b/utils.cpp
@@ -157,10 +157,23 @@ transform_t toTransform(const pose_t &pose) {
   return toTransformRotateFirst(0, 0, pose(2)) * toTransformRotateFirst(pose(0), pose(1), 0);
 }
 
+/* Using two generators allows us to rerun random seeds for two-threaded programs.
+ * There still might be some variation due to the dependence of the robot position
+ * on when exactly each context switch occurs.
+ *
+ * For programs with more threads, a more sophisticated solution will be necessary.
+ */
 std::normal_distribution<double> stdn_dist(0.0, 1.0);
-unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
-std::default_random_engine generator(seed);
+//long seed = std::chrono::system_clock::now().time_since_epoch().count();
+long seed = 1626474823108702150;
+std::default_random_engine main_generator(seed);
+std::default_random_engine spin_generator(seed);
 
-double stdn() {
-  return stdn_dist(generator);
+long getNormalSeed() {
+  return seed;
+}
+
+double stdn(int thread_id) {
+  if (thread_id == 0) return stdn_dist(main_generator);
+  else return stdn_dist(spin_generator);
 }

--- a/utils.h
+++ b/utils.h
@@ -67,6 +67,8 @@ double nearestHeadingBranch(double theta, double prev_theta);
 transform_t toTransform(const pose_t &pose);
 
 // One sample from a standard normal distribution
-double stdn();
+double stdn(int thread_id);
+// Returns the random seed used for the stdn() function
+long getNormalSeed();
 
 #endif

--- a/utils.h
+++ b/utils.h
@@ -66,7 +66,10 @@ double nearestHeadingBranch(double theta, double prev_theta);
 
 transform_t toTransform(const pose_t &pose);
 
-// One sample from a standard normal distribution
+// One sample from a standard normal distribution.
+// The thread_id is used to choose which random number generator to use.
+// This is important when trying to rerun a particular random seed; each thread
+// needs its own dedicated sequence of random numbers.
 double stdn(int thread_id);
 // Returns the random seed used for the stdn() function
 long getNormalSeed();

--- a/world.cpp
+++ b/world.cpp
@@ -200,7 +200,9 @@ void World::renderReadings(MyWindow &window) {
 }
 
 void World::start() {
-  std::srand(time(NULL));
+  unsigned int seed = time(NULL);
+  printf("World simulator seed: %d\n", seed);
+  std::srand(seed);
   gettimeofday(&last_gps_reading_, NULL);
   spin_thread_ = std::thread( [this] {spinSim();} );
 }

--- a/world.h
+++ b/world.h
@@ -26,8 +26,9 @@ public:
 
   void setCmdVel(double d_theta, double d_x);
 
-  points_t readLidar();
-  points_t readLandmarks();
+  /* Clients should use the default thread_id (i.e. 0) */
+  points_t readLidar(int thread_id = 0);
+  points_t readLandmarks(int thread_id = 0);
   transform_t readGPS();
   transform_t readOdom();
   URCLeg getLeg(int index);

--- a/world.h
+++ b/world.h
@@ -26,7 +26,9 @@ public:
 
   void setCmdVel(double d_theta, double d_x);
 
-  /* Clients should use the default thread_id (i.e. 0) */
+  /* The thread_id is used to choose which random number generator to use.
+   * This is useful for debugging when trying to rerun a particular random seed.
+   * If you're not worried about random reproducibility, just use the default (0). */
   points_t readLidar(int thread_id = 0);
   points_t readLandmarks(int thread_id = 0);
   transform_t readGPS();


### PR DESCRIPTION
Pose graph solves are expensive (scaling with the cube of the number of poses) so we want to prevent them from growing without bound. This PR implements automatic "trimming" that discards measurement data once it gets old enough. It saves the uncertainty on the earliest pose, so that the information from that old data is somewhat preserved.

There are two related other changes:
* change how we get random seeds, for reproducibility (useful for debugging particularly bad pose estimates)
* add some more friendly utility methods for retrieving the smoothed trajectory from the FriendlyGraph object

To test this, run `make 2D; ./2D_slam.out`