### PR TITLE
Increase the tolerance for pose graph optimization

### DIFF
--- a/graph.h
+++ b/graph.h
@@ -35,7 +35,7 @@ public:
 
   void add(AbstractFactor *f);
   double eval(const values &x);
-  void solve(const values &x0, double alpha=1.0, int maxiters=1000, double tol=1e-10);
+  void solve(const values &x0, double alpha=1.0, int maxiters=1000, double tol=1e-8);
   values x0();
   values solution();
   hessian covariance();


### PR DESCRIPTION
For some reason I was seeing situations where the optimizer would get
stuck at an error of about 1e-9 and stop improving. That shouldn't ever
happen, so there might be something wrong with the implementation. But
for now I'm just going to ignore the issue and increase the tolerance.